### PR TITLE
Load actual path of server key

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -28,7 +28,7 @@ module.exports = {
     /**
      * Your server crypto keys!
      */
-    serverKeyFile: "default_key.pem",
+    serverKeyFile: path.join(path.dirname(require.main.filename),"default_key.pem"),
     serverKeyPassFile: null,
     serverKeyPassEnvVar: null,
 


### PR DESCRIPTION
This will resolve the path to where `main.js` resides and looking for the file `default_key.pem` instead

Fixes https://github.com/spark/spark-server/issues/32