### PR TITLE
save a copy of the key provided by the photon

### DIFF
--- a/js/lib/Handshake.js
+++ b/js/lib/Handshake.js
@@ -394,10 +394,15 @@ Handshake.prototype = extend(IHandshake.prototype, {
     // * Remaining 12 bytes of message represent STM32 ID.  Server retrieves the Core's public RSA key.
     // * If the public key is not found, Server must close the connection.
     get_corekey: function () {
+		var that = this;
         utilities.get_core_key(this.coreID, function (public_key) {
             try {
                 if (!public_key) {
                     that.handshakeFail("couldn't find key for core: " + this.coreID);
+					if (that.coreProvidedPem) {
+						utilities.save_handshake_key(that.coreID, that.coreProvidedPem);
+					}
+
                     return;
                 }
 

--- a/js/lib/utilities.js
+++ b/js/lib/utilities.js
@@ -336,16 +336,23 @@ module.exports = {
         var keyFile = path.join(global.settings.coreKeysDir || settings.coreKeysDir, coreid + ".pub.pem");
         if (!fs.existsSync(keyFile)) {
             logger.log("Expected to find public key for core " + coreid + " at " + keyFile);
-            return null;
+			callback(null);
         }
         else {
             var keyStr = fs.readFileSync(keyFile).toString();
             var public_key = ursa.createPublicKey(keyStr, 'binary');
             callback(public_key);
         }
-
-
     },
+
+	save_handshake_key: function(coreid, pem) {
+		var keyFile = path.join(global.settings.coreKeysDir || settings.coreKeysDir, coreid + "_handshake.pub.pem");
+		if (!fs.existsSync(keyFile)) {
+
+			logger.log("I saved a key given during the handshake, (remove the _handshake from the filename to accept this device)", keyFile);
+			fs.writeFileSync(keyFile, pem);
+		}
+	},
 
     /**
 	 * base64 encodes raw binary into


### PR DESCRIPTION
so users can more easily provision photons.