### PR TITLE
Solve problem CryptoStream transform error TypeError: Cannot read property 'length' of null with NodeJs v6.9.2

### DIFF
--- a/js/lib/CryptoStream.js
+++ b/js/lib/CryptoStream.js
@@ -34,7 +34,16 @@ CryptoStream.prototype._transform = function (chunk, encoding, callback) {
         //assuming it comes in full size pieces
         var cipher = this.getCipher(callback);
         cipher.write(chunk);
-        cipher.end();
+
+        // PATCH from arondn2 to solve error: "CryptoStream transform error
+        // TypeError: Cannot read property 'length' of null" and "CryptoStream
+        // transform error Error: error:06065064:digital envelope
+        // routines:EVP_DecryptFinal_ex:bad decrypt"
+        try {
+          cipher.end();
+        } catch(e) {}
+        // END PATCH
+        
         cipher = null;
 
         if (!this.encrypt) {

--- a/js/lib/CryptoStream.js
+++ b/js/lib/CryptoStream.js
@@ -38,7 +38,8 @@ CryptoStream.prototype._transform = function (chunk, encoding, callback) {
         // PATCH from arondn2 to solve error: "CryptoStream transform error
         // TypeError: Cannot read property 'length' of null" and "CryptoStream
         // transform error Error: error:06065064:digital envelope
-        // routines:EVP_DecryptFinal_ex:bad decrypt"
+        // routines:EVP_DecryptFinal_ex:bad decrypt" when run with node version
+        // v6.9.2
         try {
           cipher.end();
         } catch(e) {}


### PR DESCRIPTION
Patch to solve errors: "CryptoStream transform error TypeError: Cannot read property 'length' of null" and "CryptoStream transform error Error: error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt" when a particle devices intent connect to local server running with a nodejs version v6.9.2.

![screen shot 2017-04-05 at 10 48 57 am](https://cloud.githubusercontent.com/assets/6246297/24711291/8187eb7a-19ed-11e7-9321-0fa872a12740.png)

I do not know if this change has any repercussion in other cases, but it works fine for me and maybe it do it for anyone else.
